### PR TITLE
#104: TanStack routing for app menu sidebar 

### DIFF
--- a/packages/papaya-web/src/papaya/components/nav/menu/AppMenu.tsx
+++ b/packages/papaya-web/src/papaya/components/nav/menu/AppMenu.tsx
@@ -16,12 +16,9 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import { Link, useLocation } from '@tanstack/react-router'
 import { ReactNode, useEffect } from 'react'
 import AppLogo from '../header/AppLogo'
-
-const Link = (props: any) => {
-  return <a {...props} />
-}
 
 interface AppMenuProps {
   view: 'desktop' | 'mobile'
@@ -85,8 +82,7 @@ export default function AppMenu(props: AppMenuProps) {
   const closeMenu = useAppMenuStateStore((state) => state.collapse)
   const openMenu = useAppMenuStateStore((state) => state.expand)
   const closeDrawer = useAppMenuStateStore((state) => state.closeDrawer)
-
-  const pathname = ''
+  const location = useLocation();
 
   useEffect(() => {
     const openState = localStorage.getItem(LOCAL_STORAGE_KEY)
@@ -103,14 +99,14 @@ export default function AppMenu(props: AppMenuProps) {
 
   useEffect(() => {
     closeDrawer()
-  }, [pathname])
+  }, [location.pathname])
 
   const MenuItemList = ({ children }: { children?: ReactNode }) => {
     return (
       <MenuList sx={(theme) => ({ pr: 2, minWidth: theme.spacing(24) })}>
         {children}
         {Object.entries(APP_MENU).map(([slug, menuItem]) => {
-          const selected = menuItem.pathPattern.test(pathname)
+          const selected = location.pathname.startsWith(slug);
           return (
             <MenuItem
               key={slug}
@@ -150,7 +146,7 @@ export default function AppMenu(props: AppMenuProps) {
             <CreateEntryButton expanded={false} view="desktop" />
           </Box>
           {Object.entries(APP_MENU).map(([slug, menuItem]) => {
-            const selected = menuItem.pathPattern.test(pathname)
+            const selected = location.pathname.startsWith(slug);
             return (
               <Tooltip key={slug} title={menuItem.label} placement="right">
                 <IconButton


### PR DESCRIPTION
Replaced Link a tag wrapper with TanStack Link, compute selected bool using useLocation hook from TanStack.

This at the very least will stop the page from refreshing when you select a link from the side bar, and they will change to their "selected" style as you'd expect.

Would probably be good to unify some of the component design in here too, maybe I can add that to this PR too later.